### PR TITLE
attempted fix for audio memory leak

### DIFF
--- a/src/components/ChessLogic.js
+++ b/src/components/ChessLogic.js
@@ -32,6 +32,7 @@ const ChessLogic = props => {
   const notation = useSelector(state => state.settings.notationOverlay);
   const dispatch = useDispatch();
 
+  const sound = props.sound;
   const moveSound = "moveSound";
   const captureSound = "captureSound";
   const wrongMoveSound = "wrongMoveSound";
@@ -92,7 +93,7 @@ const ChessLogic = props => {
       currentPosition.filter(square => square.id === id.end)[0].piece.length ===
       2;
 
-    didCapture ? playSound(captureSound) : playSound(moveSound);
+    didCapture ? playSound(sound, captureSound) : playSound(sound, moveSound);
     dispatch(selectPiece(id.start));
     dispatch(pieceMove(id.end));
 
@@ -153,7 +154,7 @@ const ChessLogic = props => {
         expectedMoveEnd = notationLogic[moveNumber].end;
 
         dispatch(selectPiece(null));
-        playSound(wrongMoveSound);
+        playSound(sound, wrongMoveSound);
 
         return;
       }
@@ -171,7 +172,7 @@ const ChessLogic = props => {
           .filter(square => square.id === selectedPiece)[0]
           .piece.substring(1, 2) === "k";
 
-      didCapture ? playSound(captureSound) : playSound(moveSound);
+      didCapture ? playSound(sound, captureSound) : playSound(sound, moveSound);
 
       dispatch(pieceMove(squarePressed));
       if (isKingMove && isCastleUser(startingSquare, endingSquare)) {

--- a/src/screens/MainBoardScreen.js
+++ b/src/screens/MainBoardScreen.js
@@ -8,6 +8,7 @@ import ChessLogic from "../components/ChessLogic";
 import PopupModal from "./PopupModal";
 import FavoriteStar from "../components/FavoriteStar";
 import _ from "lodash";
+import { Audio } from "expo-av";
 
 const MainBoardScreen = props => {
 //  const OPENING_LINES = useSelector(state => state.opening.openingBook);
@@ -17,6 +18,8 @@ const MainBoardScreen = props => {
 
   const lineId = useSelector(state => state.opening.selectedOpening);
   const moveNumber = useSelector(state => state.board.moveNumber);
+
+  const sound = new Audio.Sound();
 
   const favoriteOpenings = useSelector(state => state.playlist.playlist);
 
@@ -117,6 +120,7 @@ const MainBoardScreen = props => {
         <ChessLogic
           handleModalVisible={handleLineFinish}
           pieceColor={blackOrWhite}
+          sound={sound}
         />
       </View>
 <ScrollView

--- a/src/utils/sound.js
+++ b/src/utils/sound.js
@@ -1,27 +1,21 @@
-import { Audio } from "expo-av";
-
-
-
-const playSound = async sound => {
+const playSound = async (ref, sound) => {
   try {
     if (sound === "moveSound") {
-      const moveSound = new Audio.Sound();      
-      await moveSound.loadAsync(require("../../assets/sounds/Move.mp3"));
-      await moveSound.playAsync();
-      await moveSound.unloadAsync()
+      await ref.loadAsync(require("../../assets/sounds/Move.mp3"));
+      await ref.playAsync();
+      await ref.unloadAsync()
     }
     if (sound === "captureSound") {
-      const captureSound = new Audio.Sound();
-      await captureSound.loadAsync(require("../../assets/sounds/Capture.mp3"));
-      await captureSound.playAsync();
-      await captureSound.unloadAsync()
+      await ref.loadAsync(require("../../assets/sounds/Capture.mp3"));
+      //await captureSound.setVolumeAsync(0.5);
+      await ref.playAsync();
+      await ref.unloadAsync()
     }
     if (sound === "wrongMoveSound") {
-      const wrongMoveSound = new Audio.Sound();      
-      await wrongMoveSound.loadAsync(require("../../assets/sounds/Error.mp3"));
-      await wrongMoveSound.setVolumeAsync(0.5);
-      await wrongMoveSound.playAsync();
-      await wrongMoveSound.unloadAsync()
+      await ref.loadAsync(require("../../assets/sounds/Error.mp3"));
+      await ref.setVolumeAsync(0.5);
+      await ref.playAsync();
+      await ref.unloadAsync()
     }
   } catch (error) {
     console.log("audio loading failed");


### PR DESCRIPTION
It looks like Audio.Sound should only be created once and then passed
around as necessary.  This changes 'playSound' so that it accepts the
object itself as its first argument; the object is passed to ChessLogic
via props.